### PR TITLE
Crash Fix

### DIFF
--- a/PullToRefreshView.m
+++ b/PullToRefreshView.m
@@ -204,6 +204,8 @@
 #pragma mark Dealloc
 
 - (void)dealloc {
+	[scrollView removeObserver:self forKeyPath:@"contentOffset"];
+	
     [arrowImage release];
     [activityView release];
     [statusLabel release];


### PR DESCRIPTION
Fix a bug where PullToRefreshView wasn't removing itself as an observer from the scroll view, causing a crash.
