### PR TITLE
Added "Add Quartz framework" to the implementation instructions, "arrow@2x.png"

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,8 @@ It is:
  - doesn't suck
 
 To implement it:
- - add the three files (PullToRefreshView.{h,m} and arrow.png) to your project
+ - add the four files (PullToRefreshView.{h,m}, arrow.png and arrow@2x.png) to your project
+ - add the Quartz framework to your project if you haven't done so yet
  - #import "PullToRefreshView.h"
  - add an ivar: PullToRefreshView *pull; // or whatever you want to name it
  - in loadView or viewDidLoad, add this (and be sure to release in dealloc/viewDidUnload, etc):


### PR DESCRIPTION
It requires it, so why not add it to the instructions?
