### PR TITLE
Fix breakages mentioned in Issue 12 and ensure pullToRefreshViewShouldRe...

### DIFF
--- a/PullToRefreshView.m
+++ b/PullToRefreshView.m
@@ -82,7 +82,7 @@
 		subtitleLabel.textAlignment = UITextAlignmentCenter;
 		[self addSubview:subtitleLabel];
 
-		statusLabel = [[UILabel alloc] init];
+		statusLabel = [[UILabel alloc] initWithFrame:CGRectMake(0.0f, frame.size.height - 48.0f, self.frame.size.width, 20.0f)];
 		statusLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 		statusLabel.font = [UIFont systemFontOfSize:12.f];
 		statusLabel.textColor = kPullToRefreshViewTitleColor;
@@ -108,6 +108,8 @@
 #endif
 
 		[self.layer addSublayer:arrowImage];
+
+        [self setState:kPullToRefreshViewStateNormal];
 	}
 
 	return self;
@@ -167,6 +169,8 @@
             [self showActivity:YES animated:YES];
             [self setImageFlipped:NO];
 		    scrollView.contentInset = UIEdgeInsetsMake(fminf(-scrollView.contentOffset.y, -kPullToRefreshViewTriggerOffset), 0, 0, 0);
+            if ([delegate respondsToSelector:@selector(pullToRefreshViewShouldRefresh:)])
+                [delegate pullToRefreshViewShouldRefresh:self];
 		    break;
 		default:
 		    break;
@@ -213,9 +217,6 @@
 				[UIView setAnimationDuration:kPullToRefreshViewAnimationDuration];
 				[self setState:kPullToRefreshViewStateLoading];
 				[UIView commitAnimations];
-
-				if ([delegate respondsToSelector:@selector(pullToRefreshViewShouldRefresh:)])
-					[delegate pullToRefreshViewShouldRefresh:self];
 			}
 		}
 


### PR DESCRIPTION
...fresh is called when beginLoading is called.

Issue #12 mentions a few problems that gmckenzi found fixes for a few months ago.  Since he never made a pull request and I am using this code right now, I went ahead and made it myself.  

I also found that pullToRefreshViewShouldRefresh was not getting called in the delegate after calling beginLoading like I expected, so I moved the call into setState: so it is always called.
